### PR TITLE
FEAT: Fixed bug in team organization chart component

### DIFF
--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -55,7 +55,7 @@ export default function TeamOrgChart() {
                 )}
                 {member.github && (
                   <a
-                    href={`https://github.com/${member.github}`}
+                    href={member.github}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-gray-300 hover:text-white transition-colors"


### PR DESCRIPTION
<img width="472" height="169" alt="Screenshot From 2025-09-06 18-48-41" src="https://github.com/user-attachments/assets/d1ecda58-ca0e-4aa4-bdac-2acd450acb51" />
in our previous code, we had a bug inside team card component, it was redirecting to a wrongly generated github profile link, the bug has been fixed here